### PR TITLE
Make build aware of ENV

### DIFF
--- a/applications/the-coffee-bar-frontend/Dockerfile
+++ b/applications/the-coffee-bar-frontend/Dockerfile
@@ -26,6 +26,4 @@ ENV CHOKIDAR_USEPOLLING=true
 # Fix for timezone
 RUN ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
-RUN npm run build
-
-CMD ["npm", "run", "serve"]
+CMD ["npm", "run", "build-and-serve"]

--- a/applications/the-coffee-bar-frontend/package.json
+++ b/applications/the-coffee-bar-frontend/package.json
@@ -22,7 +22,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "serve": "serve -p 3000 build"
+    "serve": "serve -p 3000 build",
+    "build-and-serve": "npm run build && npm run serve"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
With #72 I've introduced bug - `npm run build` renders content with current environment. We need a build step to be a part of CMD in dockerfile in order to be able to use ENVs passed from docker run context.