### PR TITLE
Updated values.yaml and helm templates

### DIFF
--- a/deployments/helm/sumologic-the-coffee-bar/templates/_helpers.tpl
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/_helpers.tpl
@@ -560,12 +560,24 @@ Create envs
 - name: {{ $name }}
   value: {{ $value | quote -}}
 {{ end }}
+{{- if .Values.extras.reactAppCoffeebarBackendUrl }}
+- name: REACT_APP_COFFEE_BAR_URL
+  value: {{ .Values.extras.reactAppCoffeebarBackendUrl | quote }}
+{{- else }}
 - name: REACT_APP_COFFEE_BAR_URL
   value: {{ printf "http://%s:8082/order" ( include "sumologic.thecoffeebar.metadata.name.bar.service" . ) | quote }}
+{{- end }}
+
 - name: REACT_APP_COLLECTION_SOURCE_URL
   value: {{ .Values.extras.rumColSourceUrl | quote }}
+
+{{- if .Values.extras.reactAppPropagationCorsUrls }}
+- name: REACT_APP_PROPAGATION_CORS_URLS
+  value: {{ .Values.extras.reactAppPropagationCorsUrls | quote }}
+{{- else }}
 - name: REACT_APP_PROPAGATION_CORS_URLS
   value: {{ printf "[/^http:\\\\/\\\\/%s:8082\\\\/.*/,]" ( include "sumologic.thecoffeebar.metadata.name.bar.service" . ) | quote }}
+{{- end }}
 {{- end }}
 
 {{ define "sumologic.thecoffeebar.envs.bar" }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/bar/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/bar/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.bar.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.bar.labels }}
+    {{ toYaml .Values.customLabels.bar.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCountBar }}
+  replicas: {{ .Values.replicaCount.bar.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.bar" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.bar.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -58,16 +61,19 @@ spec:
             initialDelaySeconds: {{ .Values.healthChecks.pythonApps.readinessProbe.initialDelaySeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.python.common | nindent 12 }}
+            {{- toYaml .Values.resources.bar | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.bar.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.bar.enabled }}
+      priorityClassName: {{ .Values.podPriority.bar.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/bar/services.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/bar/services.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.bar.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.bar.labels }}
+    {{ toYaml .Values.customLabels.bar.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:
@@ -15,6 +18,7 @@ spec:
   selector:
     app: {{ include "sumologic.thecoffeebar.selectorLabels.bar" . }}
 ---
+{{- if .Values.loadBalancers.bar.enabled }}      
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,3 +35,4 @@ spec:
       name: http
   selector:
     app: {{ include "sumologic.thecoffeebar.selectorLabels.bar" . }}
+{{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/calculatorsvc/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/calculatorsvc/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.calculatorsvc.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.calculatorsvc.labels }}
+    {{ toYaml .Values.customLabels.calculatorsvc.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.calculatorsvc.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.calculatorsvc" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.calculatorsvc.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,11 +66,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.calculatorsvc.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.calculatorsvc.enabled }}
+      priorityClassName: {{ .Values.podPriority.calculatorsvc.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/calculatorsvc/service.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/calculatorsvc/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.calculatorsvc.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.calculatorsvc.labels }}
+    {{ toYaml .Values.customLabels.calculatorsvc.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/cashdesk/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/cashdesk/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.cashdesk.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.cashdesk.labels }}
+    {{ toYaml .Values.customLabels.cashdesk.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.cashdesk.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.cashdesk" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.cashdesk.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -58,16 +61,19 @@ spec:
             initialDelaySeconds: {{ .Values.healthChecks.pythonApps.readinessProbe.initialDelaySeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.python.common | nindent 12 }}
+            {{- toYaml .Values.resources.cashdesk | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.cashdesk.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.cashdesk.enabled }}
+      priorityClassName: {{ .Values.podPriority.cashdesk.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/cashdesk/service.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/cashdesk/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.cashdesk.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.cashdesk.labels }}
+    {{ toYaml .Values.customLabels.cashdesk.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/clicker/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/clicker/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.clicker.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.clicker.labels }}
+    {{ toYaml .Values.customLabels.clicker.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCountClicker }}
+  replicas: {{ .Values.replicaCount.clicker.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.clicker" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.clicker.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -58,11 +61,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.clicker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.clicker.enabled }}
+      priorityClassName: {{ .Values.podPriority.clicker.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/coffeemachine/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/coffeemachine/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.coffeemachine.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.coffeemachine.labels }}
+    {{ toYaml .Values.customLabels.coffeemachine.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.coffeemachine.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.coffeemachine" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.coffeemachine.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -58,16 +61,19 @@ spec:
             initialDelaySeconds: {{ .Values.healthChecks.pythonApps.readinessProbe.initialDelaySeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.python.common | nindent 12 }}
+            {{- toYaml .Values.resources.coffeemachine | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.coffeemachine.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.coffeemachine.enabled }}
+      priorityClassName: {{ .Values.podPriority.coffeemachine.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/coffeemachine/service.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/coffeemachine/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.coffeemachine.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.coffeemachine.labels }}
+    {{ toYaml .Values.customLabels.coffeemachine.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/coffeesvc/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/coffeesvc/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.coffeesvc.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.coffeesvc.labels }}
+    {{ toYaml .Values.customLabels.coffeesvc.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.coffeesvc.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.coffeesvc" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.coffeesvc.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -58,16 +61,19 @@ spec:
             initialDelaySeconds: {{ .Values.healthChecks.rubyApps.readinessProbe.initialDelaySeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.ruby.common | nindent 12 }}
+            {{- toYaml .Values.resources.coffeesvc | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.coffeesvc.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.coffeesvc.enabled }}
+      priorityClassName: {{ .Values.podPriority.coffeesvc.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/coffeesvc/service.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/coffeesvc/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.coffeesvc.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.coffeesvc.labels }}
+    {{ toYaml .Values.customLabels.coffeesvc.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcronbar.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcronbar.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: deployment-restart-bar

--- a/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcroncashdesk.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcroncashdesk.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: deployment-restart-cashdesk

--- a/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcronclicker.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcronclicker.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: deployment-restart-clicker

--- a/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcronpostgres.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/deployment-restart/restartcronpostgres.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: deployment-restart-postgres

--- a/deployments/helm/sumologic-the-coffee-bar/templates/frontend/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/frontend/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.frontend.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.frontend.labels }}
+    {{ toYaml .Values.customLabels.frontend.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.frontend.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.frontend" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.frontend.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,11 +66,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.frontend.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.frontend.enabled }}
+      priorityClassName: {{ .Values.podPriority.frontend.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/frontend/services.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/frontend/services.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.frontend.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.frontend.labels }}
+    {{ toYaml .Values.customLabels.frontend.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:
@@ -15,6 +18,7 @@ spec:
   selector:
     app: {{ include "sumologic.thecoffeebar.selectorLabels.frontend" . }}
 ---
+{{- if .Values.loadBalancers.frontend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,3 +35,4 @@ spec:
       name: http
   selector:
     app: {{ include "sumologic.thecoffeebar.selectorLabels.frontend" . }}
+{{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/machinesvc/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/machinesvc/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.machinesvc.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.machinesvc.labels }}
+    {{ toYaml .Values.customLabels.machinesvc.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.machinesvc.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.machinesvc" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.machinesvc.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -58,16 +61,19 @@ spec:
             initialDelaySeconds: {{ .Values.healthChecks.rubyApps.readinessProbe.initialDelaySeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.ruby.common | nindent 12 }}
+            {{- toYaml .Values.resources.machinesvc | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.machinesvc.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.machinesvc.enabled }}
+      priorityClassName: {{ .Values.podPriority.machinesvc.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/machinesvc/service.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/machinesvc/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.machinesvc.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.machinesvc.labels }}
+    {{ toYaml .Values.customLabels.machinesvc.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/postgres/configmap.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/postgres/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     db: {{ include "sumologic.thecoffeebar.labels.app.postgres.configmap" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.postgres.labels }}
+    {{ toYaml .Values.customLabels.postgres.labels | nindent 4 }}
+    {{- end }}
 data:
   init-sql: |
     ALTER SYSTEM SET log_checkpoints = on;
@@ -20,7 +23,7 @@ data:
     CREATE DATABASE account;
     GRANT ALL PRIVILEGES ON DATABASE account TO account;
     \c account;
-    
+
     CREATE TABLE IF NOT EXISTS account (
                                         id SERIAL PRIMARY KEY,
                                         product VARCHAR(255),

--- a/deployments/helm/sumologic-the-coffee-bar/templates/postgres/persistentvolume.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/postgres/persistentvolume.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     volume: {{ include "sumologic.thecoffeebar.selectorLabels.postgres.volume" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.postgres.labels }}
+    {{ toYaml .Values.customLabels.postgres.labels | nindent 4 }}
+    {{- end }}
 spec:
   storageClassName: manual
   capacity:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/postgres/persistentvolumeclaim.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/postgres/persistentvolumeclaim.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     volumeClaim: {{ include "sumologic.thecoffeebar.labels.app.postgres.volume.claim" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.postgres.labels }}
+    {{ toYaml .Values.customLabels.postgres.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/postgres/service.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/postgres/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.postgres.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.postgres.labels }}
+    {{ toYaml .Values.customLabels.postgres.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deployments/helm/sumologic-the-coffee-bar/templates/postgres/statefulset.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/postgres/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
       labels:
         app: {{ include "sumologic.thecoffeebar.selectorLabels.postgres" . }}
         {{- if .Values.customLabels.postgres.metadataLabels }}
-        {{ toYaml .Values.customLabels.postgres.metadataLabels | nindent 4 }}
+        {{ toYaml .Values.customLabels.postgres.metadataLabels | nindent 8 }}
         {{- end }}
 
         {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 8 }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/postgres/statefulset.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/postgres/statefulset.yaml
@@ -5,21 +5,28 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.postgres.statefulset" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.postgres.labels }}
+    {{ toYaml .Values.customLabels.postgres.labels | nindent 4 }}
+    {{- end }}
 spec:
   serviceName: {{ include "sumologic.thecoffeebar.metadata.name.postgres.statefulset" . }}
-  replicas: {{ .Values.replicaCountPostgres }}
+  replicas: {{ .Values.replicaCount.postgres.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.postgres" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.postgres.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
         app: {{ include "sumologic.thecoffeebar.selectorLabels.postgres" . }}
+        {{- if .Values.customLabels.postgres.metadataLabels }}
+        {{ toYaml .Values.customLabels.postgres.metadataLabels | nindent 4 }}
+        {{- end }}
+
         {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -89,11 +96,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.postgres.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.postgres.enabled }}
+      priorityClassName: {{ .Values.podPriority.postgres.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/watersvc/deployment.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/watersvc/deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.watersvc.deployment" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.watersvc.labels }}
+    {{ toYaml .Values.customLabels.watersvc.labels | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.watersvc.replicas }}
   selector:
     matchLabels:
       app: {{ include "sumologic.thecoffeebar.selectorLabels.watersvc" . }}
       {{- include "sumologic.thecoffeebar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.podAnnotations.watersvc.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -58,16 +61,19 @@ spec:
             initialDelaySeconds: {{ .Values.healthChecks.rubyApps.readinessProbe.initialDelaySeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.ruby.common | nindent 12 }}
+            {{- toYaml .Values.resources.watersvc | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinityRule.watersvc.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podPriority.watersvc.enabled }}
+      priorityClassName: {{ .Values.podPriority.watersvc.priorityClassName }}
       {{- end }}

--- a/deployments/helm/sumologic-the-coffee-bar/templates/watersvc/service.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/templates/watersvc/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: {{ include "sumologic.thecoffeebar.labels.app.watersvc.service" . }}
     {{- include "sumologic.thecoffeebar.labels.common" . | nindent 4 }}
+    {{- if .Values.customLabels.watersvc.labels }}
+    {{ toYaml .Values.customLabels.watersvc.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deployments/helm/sumologic-the-coffee-bar/values.yaml
+++ b/deployments/helm/sumologic-the-coffee-bar/values.yaml
@@ -2,10 +2,31 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-replicaCountClicker: 1
-replicaCountBar: 1
-replicaCountPostgres: 2
+nameOverride: ""
+fullnameOverride: ""
+
+## Specifies number of pod replicas running at any given time
+replicaCount:
+  frontend:
+    replicas: 1
+  calculatorsvc:
+    replicas: 1
+  clicker:
+    replicas: 1
+  postgres:
+    replicas: 1
+  cashdesk:
+    replicas: 1
+  bar:
+    replicas: 1
+  coffeesvc:
+    replicas: 1
+  coffeemachine:
+    replicas: 1
+  machinesvc:
+    replicas: 1
+  watersvc:
+    replicas: 1
 
 image:
   dotnet:
@@ -29,10 +50,7 @@ image:
 
   pullPolicy: Always
 
-
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -43,7 +61,59 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+## Create a load balancer for bar service and frontend servic
+loadBalancers:
+  bar:
+    enabled: true
+  frontend:
+    enabled: true
+
+## Custom labels to apply to service, deployment and pods
+customLabels:
+  frontend:
+    labels: {}
+  calculatorsvc:
+    labels: {}
+  clicker:
+    labels: {}
+  postgres:
+    labels: {}
+    metadataLabels: {}
+  cashdesk:
+    labels: {}
+  bar:
+    labels: {}
+  coffeesvc: 
+    labels: {}
+  coffeemachine:
+    labels: {}
+  machinesvc:
+    labels: {}
+  watersvc:
+    labels: {}
+
+## Custom pod annotations to apply to deployment
+podAnnotations:
+  frontend:
+    podAnnotations: {}
+  calculatorsvc:
+    podAnnotations: {}
+  clicker:
+    podAnnotations: {}
+  postgres:
+    podAnnotations: {}
+  cashdesk:
+    podAnnotations: {}
+  bar:
+    podAnnotations: {}
+  coffeesvc:
+    podAnnotations: {}
+  coffeemachine:
+    podAnnotations: {}
+  machinesvc:
+    podAnnotations: {}
+  watersvc:
+    podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000
@@ -90,38 +160,22 @@ ingress:
 resources:
   frontend:
     requests:
-      cpu: 500m
+      cpu: 300m
       memory: 512Mi
     limits:
-      cpu: 1000m
+      cpu: 800m
       memory: 768Mi
-  python:
-    common:
-      requests:
-        cpu: 100m
-        memory: 50Mi
-      limits:
-        cpu: 250m
-        memory: 400Mi
-  ruby:
-    common:
-      requests:
-        cpu: 100m
-        memory: 50Mi
-      limits:
-        cpu: 250m
-        memory: 250Mi
   calculatorsvc:
     common:
       requests:
-        cpu: 100m
+        cpu: 50m
         memory: 50Mi
       limits:
-        cpu: 250m
-        memory: 500Mi
+        cpu: 150m
+        memory: 250Mi
   clicker:
     requests:
-      cpu: 200m
+      cpu: 250m
       memory: 512Mi
     limits:
       cpu: 500m
@@ -133,11 +187,53 @@ resources:
     limits:
       cpu: 500m
       memory: 500Mi
+  cashdesk:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 200m
+      memory: 200Mi
+  bar:
+    requests:
+      cpu: 50m
+      memory: 50Mi
+    limits:
+      cpu: 200m
+      memory: 200Mi
+  coffeesvc:
+    requests:
+      cpu: 50m
+      memory: 50Mi
+    limits:
+      cpu: 150m
+      memory: 150Mi
+  coffeemachine:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 250m
+      memory: 300Mi
+  machinesvc:
+    requests:
+      cpu: 50m
+      memory: 50Mi
+    limits:
+      cpu: 150m
+      memory: 150Mi
+  watersvc:
+    requests:
+      cpu: 50m
+      memory: 60Mi
+    limits:
+      cpu: 150m
+      memory: 200Mi
 
 healthChecks:
   calculator:
     livenessProbe:
-      enabled: false
+      enabled: true
       exec:
         command:
           - /bin/sh
@@ -160,7 +256,7 @@ healthChecks:
       initialDelaySeconds: 15
   clicker:
     livenessProbe:
-      enabled: false
+      enabled: true
       exec:
         command:
           - /bin/sh
@@ -183,7 +279,7 @@ healthChecks:
       initialDelaySeconds: 15
   frontend:
     livenessProbe:
-      enabled: false
+      enabled: true
       exec:
         command:
           - /bin/sh
@@ -229,7 +325,7 @@ healthChecks:
       initialDelaySeconds: 15
   rubyApps:
     livenessProbe:
-      enabled: false
+      enabled: true
       exec:
         command:
           - /bin/sh
@@ -255,20 +351,78 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## By default we don't set affinity:
+affinityRule:
+  frontend:
+    affinity: {}
+  calculatorsvc:
+    affinity: {}
+  clicker:
+    affinity: {}
+  postgres:
+    affinity: {}
+  cashdesk:
+    affinity: {}
+  bar:
+    affinity: {}
+  coffeesvc:
+    affinity: {}
+  coffeemachine:
+    affinity: {}
+  machinesvc:
+    affinity: {}
+  watersvc:
+    affinity: {}
 
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical
+## By default we don't set pod priority:
+podPriority:
+  frontend:
+    enabled: false
+    priorityClassName:
+  calculatorsvc:
+    enabled: false
+    priorityClassName:
+  clicker:
+    enabled: false
+    priorityClassName:
+  postgres:
+    enabled: false
+    priorityClassName:
+  cashdesk:
+    enabled: false
+    priorityClassName:
+  bar:
+    enabled: false
+    priorityClassName:
+  coffeesvc:
+    enabled: false
+    priorityClassName:
+  coffeemachine:
+    enabled: false
+    priorityClassName:
+  machinesvc:
+    enabled: false
+    priorityClassName:
+  watersvc:
+    enabled: false
+    priorityClassName:
+
+## added deployment.environment=default in OTEL_RESOURCE_ATTRIBUTES for all services
+## added REACT_APP_ENVIRONMENT_NAME: "default" & OTEL_TRACES_EXPORTER: "otlp_proto_http" in frontend service
 envs:
   bar:
-    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app"
+    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app,deployment.environment=default"
     OTEL_SERVICE_NAME: "the-coffee-bar"
     OTEL_PROPAGATORS: "b3,tracecontext,baggage"
     OTEL_METRICS_EXPORTER: "none"
   calculatorsvc:
-    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app"
+    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app,deployment.environment=default"
     OTEL_SERVICE_NAME: "calculator-svc"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
   cashdesk:
-    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app"
+    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app,deployment.environment=default"
     OTEL_SERVICE_NAME: "the-cashdesk"
     OTEL_PROPAGATORS: "b3,tracecontext,baggage"
     OTEL_METRICS_EXPORTER: "none"
@@ -283,12 +437,12 @@ envs:
     SPIKE_DURATION: "300"  # in seconds, Use 3600 for 1 hour
     CPU_SPIKE_PROCESSES: "1"
     NETWORK_DELAY: "1sec"
-    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app"
+    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app,deployment.environment=default"
     OTEL_PROPAGATORS: "b3,tracecontext,baggage"
     OTEL_SERVICE_NAME: "the-coffee-machine"
     OTEL_METRICS_EXPORTER: "none"
   coffeesvc:
-    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app"
+    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app,deployment.environment=default"
     OTEL_PROPAGATORS: "b3,tracecontext,baggage"
     OTEL_SERVICE_NAME: "coffee-svc"
   frontend:
@@ -307,24 +461,27 @@ envs:
     SPIKE_DURATION: "300"  # for 5 minutes
     CPU_SPIKE_PROCESSES: "1"  # on 1 process
     NETWORK_DELAY: "1sec"  # with 100 ms network delay
+    OTEL_TRACES_EXPORTER: "otlp_proto_http"
   machinesvc:
-    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app"
+    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app,deployment.environment=default"
     OTEL_PROPAGATORS: "b3,tracecontext,baggage"
     OTEL_SERVICE_NAME: "machine-svc"
   postgres:
     POSTGRES_HOST_AUTH_METHOD: trust
   watersvc:
-    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app"
+    OTEL_RESOURCE_ATTRIBUTES: "application=the-coffee-bar-app,deployment.environment=default"
     OTEL_PROPAGATORS: "b3,tracecontext,baggage"
     OTEL_SERVICE_NAME: "water-svc"
 
 crons:
-  clicker: '30 */4 * * *'  # cron spec of time, here, 4 o'clock
-  postgres: '30 */8 * * *'  # cron spec of time, here, 8 o'clock
-  cashdesk: '30 */8 * * *'  # cron spec of time, here, 8 o'clock
-  bar: '30 */8 * * *'  # cron spec of time, here, 8 o'clock
+  clicker: '30 */4 * * *' # cron spec of time, here, 4 o'clock
+  postgres: '30 */8 * * *' # cron spec of time, here, 8 o'clock
+  cashdesk: '30 */4 * * *' # cron spec of time, here, 4 o'clock
+  bar: '30 */4 * * *' # cron spec of time, here, 4 o'clock
 
 extras:
-  otelColHostName: collection-sumologic-otelcol.sumologic
+  otelColHostName: collection-sumologic-otelcol.collection
   lambdaCakesUrl:
   rumColSourceUrl:
+  reactAppCoffeebarBackendUrl:
+  reactAppPropagationCorsUrls:


### PR DESCRIPTION
- Added support to set different custom fields (service-wise) in deployment specific values.yaml files.
- Updated service templates accordingly.

Added support for updating:
- `replicas`
- `labels`
- `annotations`
-  `resources`
- `affinity rules`
- `priority classes`